### PR TITLE
Fixes for windows and another small issues

### DIFF
--- a/headers/globals.h
+++ b/headers/globals.h
@@ -2,7 +2,7 @@
 #include <SDL2/SDL_joystick.h>
 #include <SDL2/SDL_render.h>
 #include <SDL2/SDL_video.h>
-#include <bits/types/FILE.h>
+#include <stdio.h>
 #include <stdint.h>
 
 #ifndef GLOBALS_H

--- a/makefile
+++ b/makefile
@@ -7,8 +7,6 @@ ARCH ?= amd64
 TEMP_DIR ?= perdita_$(VERSION)_$(ARCH)
 CONTROL ?= $(TEMP_DIR)/DEBIAN/control
 
-
-
 SDL_WIN = ${HOME}/sdl_win/SDL2-2.0.18/x86_64-w64-mingw32
 LIB_WIN = -L$(SDL_WIN)/lib
 INCL_WIN = -I$(SDL_WIN)/include -I$(SDL_WIN)/include/SDL2
@@ -16,6 +14,7 @@ INCL_WIN = -I$(SDL_WIN)/include -I$(SDL_WIN)/include/SDL2
 SRCDIR = src
 INCDIR = headers/
 OBJDIR = obj
+OBJDIR_WIN = obj_win
 
 # List all source files in the src/ directory
 SRCFILES := $(wildcard $(SRCDIR)/*.c)
@@ -23,7 +22,14 @@ SRCFILES := $(wildcard $(SRCDIR)/*.c)
 # Generate object file names from source files
 OBJFILES := $(patsubst $(SRCDIR)/%.c, $(OBJDIR)/%.o, $(SRCFILES))
 
+# Generate object file names from source files for windows
+OBJFILES_WIN := $(patsubst $(SRCDIR)/%.c, $(OBJDIR_WIN)/%.win.o, $(SRCFILES))
+
 all: perdita
+
+###############
+# Linux BUILD #
+###############
 
 # Rule to generate object files from source files
 $(OBJDIR)/%.o: $(SRCDIR)/%.c | $(OBJDIR)
@@ -41,22 +47,38 @@ perdita_debug: $(OBJFILES)
 version.h: $(SRCFILES)
 	echo "char * perdita_version=\"$(VERSION)-$$(git rev-parse --short HEAD)\";"> version.h
 
+#################
+# WINDOWS BUILD #
+#################W
+
 # Generate Windows Version. You can use the Docker file in https://github.com/zerasul/dockerretro/blob/master/sdl/Dockerfile
 # To generate this file.
+$(OBJDIR_WIN)/%.win.o: $(SRCDIR)/%.c | $(OBJDIR_WIN)
+	x86_64-w64-mingw32-gcc $(INCL_WIN) $(LIB_WIN) $(COMPILER_FLAGS_WIN) $< -o $@ -I$(INCDIR)
+
+$(OBJDIR_WIN):
+	mkdir -p $(OBJDIR_WIN)
+
 perdita.zip: perdita.exe
 	zip -j perdita.zip perdita.exe $(SDL_WIN)/bin/SDL2.dll
 
-perdita.exe: perdita.win.o
-	x86_64-w64-mingw32-g++ $(LIB_WIN) -static perdita.win.o  `$(SDL_WIN)/bin/sdl2-config --static-libs` -o perdita.exe
+perdita.exe: version.h $(OBJFILES_WIN)
+	x86_64-w64-mingw32-g++ $(LIB_WIN) -static $(OBJFILES_WIN) `$(SDL_WIN)/bin/sdl2-config --static-libs` -o perdita.exe
 
-perdita.win.o: version.h $(SRCFILES)
-	x86_64-w64-mingw32-gcc $(INCL_WIN) $(LIB_WIN) $(COMPILER_FLAGS_WIN) $(SRCFILES) -I$(INCDIR) -o $@
-
+# Clean for linux
 clean:
-	rm -f perdita; rm -f perdita_debug; rm -f perdita.exe; rm -f perdita.zip; rm -f perdita.win.o version.h $(OBJFILES) $(TEMP_DIR)
+	clean:
+	rm -f perdita perdita_debug perdita.exe perdita.zip version.h
+	rm -f $(OBJDIR)/*.o $(OBJDIR)/*.win.o
+	rm -rf $(TEMP_DIR)
+
+# Clean for windows
+clean-win:
+	- del /q perdita perdita_debug perdita.exe perdita.zip version.h 2>nul
+	- del /q $(OBJDIR_WIN)\*.o $(OBJDIR_WIN)\*.win.o 2>nul
+	- rmdir /s /q $(TEMP_DIR) 2>nul
 
 make-deb: perdita
-	mkdir $(TEMP_DIR)
 	mkdir -p $(TEMP_DIR)/usr/local/bin
 	mkdir -p $(TEMP_DIR)/DEBIAN
 

--- a/src/memory_management.c
+++ b/src/memory_management.c
@@ -1,3 +1,6 @@
+#include <stdlib.h>
+#include <time.h>
+
 #include "memory_management.h"
 
 /* *** memory management *** */

--- a/src/opcodes.c
+++ b/src/opcodes.c
@@ -55,8 +55,8 @@ void adc(byte d) {
 	big += (p & 1);			// add with Carry (A was computer just after this)
 
 	if (p & 0b00001000) {						// Decimal mode!
-		high = (old & $F0)+(d & $F0)			// compute carry-less LSN
-		if (((big & 0x0F) > 9)||(high != (big & $F0))) {		// LSN overflow? was 'a' instead of 'big'
+		high = (old & 0x0F)+(d & 0x0F);			// compute carry-less LSN
+		if (((big & 0x0F) > 9)||(high != (big & 0x0F))) {		// LSN overflow? was 'a' instead of 'big'
 			big += 6;											// get into next decade
 		}
 		if (((big & 0xF0) > 0x90)||(big & 256)) {				// MSN overflow?

--- a/src/perdita.c
+++ b/src/perdita.c
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
 	char *rom_addr=NULL;
 	char *exe_addr=NULL;
 	int rom_addr_int;
-	int exe_addr_int;
+	int exe_addr_int=0;
 
 	redefine();		// finish keyboard layout definitions
 	//Show Title And Version

--- a/src/roms.c
+++ b/src/roms.c
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include "roms.h"
 
 /* load firmware, arbitrary position */

--- a/src/vdu.c
+++ b/src/vdu.c
@@ -1,5 +1,6 @@
 #include <SDL2/SDL.h>
 #include <string.h>
+#include <math.h>
 
 #include "vdu.h"
 #include "globals.h"


### PR DESCRIPTION
I spent this afternoon trying to compile and build the emulator to test Durango on my Windows machine. While doing so, I encountered some minor issues that required a few fixes, which I’ve included in this pull request.

### Changelog
- Replaced `<bits/types/FILE.h>` with `<stdio.h>` to ensure better portability and avoid compatibility issues on Windows OS.https://github.com/durangoretro/Perdita/commit/804177b228f7337bceb50f57a2b4abf217f0478c.
- Added some missing libraries in the includes https://github.com/durangoretro/Perdita/commit/83662c43ca8fc9e39b41814ca1dd5977e09bcc86.
- Fixed minor code mistakes, such as using '$F0' instead of '0xF0', and added a forgotten ';' https://github.com/durangoretro/Perdita/commit/61fc94a815d62af4bd2e46af90b72032cbdc579f.
- Initialized the following variable to '0', just to avoid warnings related to undeclared variables https://github.com/durangoretro/Perdita/commit/9f4f7f6e2b0f2efea63e8d64a106fcaa323e644b.
- Updated the Makefile to support Windows OS and also added a clean windows method https://github.com/durangoretro/Perdita/commit/b69886d563a3ee1f77faafa2d3f17f803b7140c4.